### PR TITLE
[DLS-6754] make the consultation number upper case only for a11y

### DIFF
--- a/app/uk/gov/hmrc/vatregisteredcompanies/models/package.scala
+++ b/app/uk/gov/hmrc/vatregisteredcompanies/models/package.scala
@@ -30,7 +30,7 @@ package object models {
   object ConsultationNumber {
     def generate: ConsultationNumber =
       new Random().alphanumeric.filter(x =>
-        x.toLower >= 'a' && x.toLower <= 'z'
+        x.toString.matches("[A-Z&&[^BGIOSZ]]")
       ).take(9).toList.mkString.replaceAll("...(?!$)", "$0-")
   }
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -25,7 +25,6 @@ object AppDependencies {
     "org.mockito"             %  "mockito-core"             % "5.4.0"             % "test",
     "org.scalatestplus"       %% "mockito-3-4"              % "3.2.10.0"          % "test, it",
     "org.pegdown"             %  "pegdown"                  % "1.6.0"             % "test, it",
-    "uk.gov.hmrc"             %% "service-integration-test" % "1.3.0-play-28"     % "test, it",
     "org.scalatestplus.play"  %% "scalatestplus-play"       % "5.1.0"             % "test, it",
     "org.scalatestplus"       %% "scalacheck-1-14"          % "3.2.2.0"           % "test, it",
     "com.vladsch.flexmark"    %  "flexmark-all"             % "0.64.8"            % "test, it",


### PR DESCRIPTION
This change makes the generated references upper case only and excludes ambiguous characters for better accessibility. The resultant reference has a probability of 20^9 of being unique.